### PR TITLE
Added max_length warning to pretrained tokenizer initialization

### DIFF
--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -60,7 +60,7 @@ class GPT2Config(PretrainedConfig):
             Number of attention heads for each attention layer in the Transformer encoder.
         n_inner (`int`, *optional*, defaults to None):
             Dimensionality of the inner feed-forward layers. `None` will set it to 4 times n_embd
-        activation_function (`str`, *optional*, defaults to `"gelu"`):
+        activation_function (`str`, *optional*, defaults to `"gelu_new"`):
             Activation function, to be selected in the list `["relu", "silu", "gelu", "tanh", "gelu_new"]`.
         resid_pdrop (`float`, *optional*, defaults to 0.1):
             The dropout probability for all fully connected layers in the embeddings, encoder, and pooler.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1530,6 +1530,14 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         # For backward compatibility we fallback to set model_max_length from max_len if provided
         model_max_length = kwargs.pop("model_max_length", kwargs.pop("max_len", None))
+
+        # To specify that 'max_length' does not set 'model_max_length',
+        if model_max_length is None and "max_length" in kwargs:
+            warnings.warn(
+                "The parameter 'max_length' is not an inherant input argument when building a tokenizer."
+                "If you wanted to set a length to truncate to, use 'model_max_length' instead."
+            )
+        
         self.model_max_length = model_max_length if model_max_length is not None else VERY_LARGE_INTEGER
 
         # Padding and truncation side are right by default and overridden in subclasses. If specified in the kwargs, it


### PR DESCRIPTION
# What does this PR do?

A truncation warning, "Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.", while not incorrect (max_length is a parameter for running the tokenize function), could also be interpreted as suggesting 'max_length' is a parameter used across the tokenizer class. However, 'max_length' silently does nothing when it is passed into AutoTokenizer.from_pretrained(), for example, and the previously mentioned warning will still occur. The proposed addition provides a simple warning when the 'model_max_length' is None and 'max_length' is passed in as an argument. The warning suggests the correct parameter name instead. This is meant to help provide a warning to direct developers to the correct variable name, helping prevent any unnecessary troubleshooting. This change should not require any additional tests or dependencies.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

CC @ArthurZucker